### PR TITLE
Use correct debugging option for phpseclib-2.0.30/SSH2

### DIFF
--- a/auth/ssh.php
+++ b/auth/ssh.php
@@ -40,7 +40,7 @@ final class SSH extends Authentication {
     $this->port = isset($this->config['port']) ? (int) $this->config['port'] : 22;
 
     if ($this->debug) {
-      define('NET_SSH2_LOGGING', NET_SSH2_LOG_COMPLEX);
+      define('NET_SSH2_LOGGING', SSH2::LOG_COMPLEX);
     }
   }
 


### PR DESCRIPTION
### Fixes: #156 

SSH debug mode sets `NET_SSH2_LOGGING` to a non-existant value `NET_SSH2_LOG_COMPLEX`. The correct value to use is `SSH2::LOG_COMPLEX`
