### PR TITLE
Mikrotik: Show matching routes for IP

### DIFF
--- a/routers/mikrotik.php
+++ b/routers/mikrotik.php
@@ -42,7 +42,7 @@ final class Mikrotik extends Router {
       $cmd->add('detail');
     }
 
-    $cmd->add('where', 'dst-address='.quote($parameter));
+    $cmd->add('where', quote($parameter).' in dst-address');
 
     return array($cmd);
   }


### PR DESCRIPTION

### Fixes:

Mikrotik: Show all matching routes for a IP. Not only full matching networks.