### PR TITLE
Fixed "show route ^AS" on routers/huawei.php. Before this commands wa…

### DIFF
--- a/routers/huawei.php
+++ b/routers/huawei.php
@@ -42,7 +42,7 @@ class Huawei extends Router {
       $cmd->add('bgp');
     }
     $parameter = str_replace('/', ' ', $parameter);
-    $cmd->add('routing-table', $parameter);
+    $cmd->add('routing-table', $parameter, '| no-more');
 
     return array($cmd);
   }
@@ -53,17 +53,27 @@ class Huawei extends Router {
     $cmd->add('display bgp');
 
     if (!$this->config['disable_ipv6']) {
-      $commands[] = (clone $cmd)->add('ipv6 routing-table regular-expression', $parameter);
+      $commands[] = (clone $cmd)->add('ipv6 routing-table regular-expression', $parameter, '| no-more');
     }
     if (!$this->config['disable_ipv4']) {
-      $commands[] = (clone $cmd)->add('routing-table regular-expression', $parameter);
+      $commands[] = (clone $cmd)->add('routing-table regular-expression', $parameter, '| no-more');
     }
 
     return $commands;
   }
 
   protected function build_as($parameter, $vrf = false) {
-    throw new Exception('Coomand not supported.');
+    $commands = array();
+    $cmd = new CommandBuilder();
+    $cmd->add('display bgp');
+
+    if (!$this->config['disable_ipv6']) {
+      $commands[] = (clone $cmd)->add('ipv6 routing-table regular-expression', '^'.$parameter, '| no-more');
+    }
+    if (!$this->config['disable_ipv4']) {
+      $commands[] = (clone $cmd)->add('routing-table regular-expression', '^'.$parameter, '| no-more');
+    }
+    return $commands;
   }
 
   protected function build_ping($parameter, $vrf = false) {


### PR DESCRIPTION
<!--
  Thank you for your interest in contributing to Looking Glass.

  Please note that our contribution policy requires that a feature request or
  bug report be opened for approval prior to filing a pull request.

  Please indicate the feature request or bug report below. If your pull
  request does not reference an accepted bug report or feature request, it will
  be marked as invalid and closed.
-->
### Fixes:
Fixed "show route ^AS" on routers/huawei.php. Before this commands was "not supported", but now it is;

Added "| no-more" on displays, eliminating the ---more---. This action does not fix every issue about it.
<!--
  Please include a summary of the proposed changes below.
-->
